### PR TITLE
fix time format

### DIFF
--- a/JSONUtil/src/main/java/org/kopitubruk/util/json/JSONConfig.java
+++ b/JSONUtil/src/main/java/org/kopitubruk/util/json/JSONConfig.java
@@ -592,7 +592,7 @@ public class JSONConfig implements Serializable, Cloneable
     {
         if ( dateGenFormat == null ){
             // don't create it until it's needed.
-            dateGenFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.sss'Z'");
+            dateGenFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
             dateGenFormat.setTimeZone(UTC_TIME_ZONE);
         }
         return dateGenFormat;


### PR DESCRIPTION
Current format outputs seconds after the dot, so 2018-11-16T06:58:50.975Z is formated to 2018-11-16T06:58:50.050Z